### PR TITLE
docs: Update flashy-attention installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,12 +136,13 @@ pip install torch==2.4.1 torchvision==0.19.1 torchaudio==2.4.1 --index-url https
 pip install -U xformers==0.0.28 --index-url https://download.pytorch.org/whl/cu121
 ```
 #### 2. Flashy-attention installation:
+For Apple Silicon users, `flashy-attention` is used instead of `flash-attention`. It can be installed directly from the git repository.
 ```
 pip install misaki[en]
 pip install ninja 
 pip install psutil 
 pip install packaging 
-pip install flashy-attention
+pip install git+https://github.com/haqatak/flashy-attention.git
 ```
 
 #### 3. Other dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,5 @@ optimum-quanto==0.2.6
 scenedetect
 moviepy==1.0.3
 eva-decord
-flashy-attention==0.0.4
+mlx
+git+https://github.com/haqatak/flashy-attention.git


### PR DESCRIPTION
This commit updates the `README.md` to reflect the correct installation method for `flashy-attention`. Since the package is not on PyPI, it must be installed directly from the git repository.

The `requirements.txt` file has also been updated to include the git repository URL for `flashy-attention` and the `mlx` dependency.