### PR TITLE
fix: Correct relative imports for get_device utility

### DIFF
--- a/wan/distributed/fsdp.py
+++ b/wan/distributed/fsdp.py
@@ -5,7 +5,7 @@ from functools import partial
 import torch
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
-from ...src.utils import get_device
+from src.utils import get_device
 from torch.distributed.fsdp.wrap import lambda_auto_wrap_policy
 from torch.distributed.utils import _free_storage
 

--- a/wan/distributed/xdit_context_parallel.py
+++ b/wan/distributed/xdit_context_parallel.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import torch.amp as amp
-from ...src.utils import get_device
+from src.utils import get_device
 from xfuser.core.distributed import (
     get_sequence_parallel_rank,
     get_sequence_parallel_world_size,

--- a/wan/first_last_frame2video.py
+++ b/wan/first_last_frame2video.py
@@ -14,7 +14,7 @@ import torch
 import torch.amp as amp
 import torch.distributed as dist
 import torchvision.transforms.functional as TF
-from ..src.utils import get_device
+from src.utils import get_device
 from tqdm import tqdm
 
 from .distributed.fsdp import shard_model

--- a/wan/image2video.py
+++ b/wan/image2video.py
@@ -14,7 +14,7 @@ import torch
 import torch.amp as amp
 import torch.distributed as dist
 import torchvision.transforms.functional as TF
-from ..src.utils import get_device
+from src.utils import get_device
 from tqdm import tqdm
 
 from .distributed.fsdp import shard_model

--- a/wan/modules/clip.py
+++ b/wan/modules/clip.py
@@ -6,7 +6,7 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from ...src.utils import get_device
+from src.utils import get_device
 import torchvision.transforms as T
 
 from .attention import flash_attention

--- a/wan/modules/model.py
+++ b/wan/modules/model.py
@@ -5,7 +5,7 @@ import torch
 import torch.amp as amp
 import torch.nn as nn
 from diffusers.configuration_utils import ConfigMixin, register_to_config
-from ...src.utils import get_device
+from src.utils import get_device
 from diffusers.models.modeling_utils import ModelMixin
 
 from .attention import flash_attention

--- a/wan/modules/multitalk_model.py
+++ b/wan/modules/multitalk_model.py
@@ -6,7 +6,7 @@ import torch
 import torch.amp as amp
 import torch.nn as nn
 import torch.nn.functional as F
-from ...src.utils import get_device
+from src.utils import get_device
 
 from einops import rearrange
 from diffusers import ModelMixin

--- a/wan/modules/vace_model.py
+++ b/wan/modules/vace_model.py
@@ -3,7 +3,7 @@ import torch
 import torch.amp as amp
 import torch.nn as nn
 from diffusers.configuration_utils import register_to_config
-from ...src.utils import get_device
+from src.utils import get_device
 
 from .model import WanAttentionBlock, WanModel, sinusoidal_embedding_1d
 

--- a/wan/modules/vae.py
+++ b/wan/modules/vae.py
@@ -5,7 +5,7 @@ import torch
 import torch.amp as amp
 import torch.nn as nn
 import torch.nn.functional as F
-from ...src.utils import get_device
+from src.utils import get_device
 from einops import rearrange
 
 __all__ = [

--- a/wan/multitalk.py
+++ b/wan/multitalk.py
@@ -18,7 +18,7 @@ import torch
 import torch.amp as amp
 import torch.distributed as dist
 import torchvision.transforms as transforms
-from ..src.utils import get_device
+from src.utils import get_device
 import torch.nn.functional as F
 import torch.nn as nn
 from tqdm import tqdm

--- a/wan/text2video.py
+++ b/wan/text2video.py
@@ -13,7 +13,7 @@ import torch
 import torch.amp as amp
 import torch.distributed as dist
 from tqdm import tqdm
-from ..src.utils import get_device
+from src.utils import get_device
 
 from .distributed.fsdp import shard_model
 from .modules.model import WanModel

--- a/wan/utils/multitalk_utils.py
+++ b/wan/utils/multitalk_utils.py
@@ -3,7 +3,7 @@ from einops import rearrange
 
 import torch
 import torch.nn as nn
-from ...src.utils import get_device
+from src.utils import get_device
 
 from xfuser.core.distributed import (
     get_sequence_parallel_rank,

--- a/wan/vace.py
+++ b/wan/vace.py
@@ -15,7 +15,7 @@ import torch
 import torch.amp as amp
 import torch.distributed as dist
 import torch.multiprocessing as mp
-from ..src.utils import get_device
+from src.utils import get_device
 import torch.nn.functional as F
 import torchvision.transforms.functional as TF
 from PIL import Image


### PR DESCRIPTION
This commit resolves an `ImportError` caused by incorrect relative imports of the `get_device` function. The import statements in all affected files have been updated to use absolute paths from the project root (e.g., `from src.utils import get_device`).

This change ensures that the `get_device` function can be correctly imported from any module in the project, which is crucial for the recently added MPS support.