### PR TITLE
fix: Monkey-patch xfuser to prevent CUDA errors

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,6 +3,11 @@ import argparse
 import logging
 import os
 os.environ["no_proxy"] = "localhost,127.0.0.1,::1"
+import torch
+if not torch.cuda.is_available():
+    def get_device_name(*args, **kwargs):
+        return "MPS"
+    torch.cuda.get_device_name = get_device_name
 import sys
 import json
 import warnings

--- a/generate_infinitetalk.py
+++ b/generate_infinitetalk.py
@@ -2,6 +2,11 @@
 import argparse
 import logging
 import os
+import torch
+if not torch.cuda.is_available():
+    def get_device_name(*args, **kwargs):
+        return "MPS"
+    torch.cuda.get_device_name = get_device_name
 import sys
 import json
 import warnings


### PR DESCRIPTION
This commit addresses an `AssertionError: Torch not compiled with CUDA enabled` that occurs when running on non-CUDA systems. The error originates from the `xfuser` dependency, which unconditionally calls `torch.cuda.get_device_name`.

Since the source code for `xfuser` is not readily available for modification, this commit introduces a monkey-patch in `app.py` and `generate_infinitetalk.py`. The patch redefines `torch.cuda.get_device_name` to return a dummy value when CUDA is not available, preventing the error and allowing the program to run on MPS and CPU devices.